### PR TITLE
Update the dependency for rpcreflect

### DIFF
--- a/jujuapidochtml/main.go
+++ b/jujuapidochtml/main.go
@@ -16,7 +16,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/apicompat/jsontypes"
+	"github.com/rogpeppe/apicompat/jsontypes"
 
 	"github.com/juju/jujuapidoc/apidoc"
 )

--- a/jujugenerateapidoc/prog.go
+++ b/jujugenerateapidoc/prog.go
@@ -25,8 +25,8 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/permission"
-	"github.com/juju/juju/rpc/rpcreflect"
 	"github.com/juju/juju/state"
+	"github.com/juju/rpcreflect"
 	"gopkg.in/juju/names.v2"
 
 	"github.com/juju/jujuapidoc/apidoc"


### PR DESCRIPTION
The RPCReflect package has been moved out so we can use it as a
dependency for code generators.